### PR TITLE
Fix hasKey utility and correct tests

### DIFF
--- a/packages/workflow/src/utils.ts
+++ b/packages/workflow/src/utils.ts
@@ -281,7 +281,7 @@ export function randomString(minLength: number, maxLength?: number): string {
  * Checks if a value is an object with a specific key and provides a type guard for the key.
  */
 export function hasKey<T extends PropertyKey>(value: unknown, key: T): value is Record<T, unknown> {
-	return value !== null && typeof value === 'object' && value.hasOwnProperty(key);
+    return value !== null && typeof value === 'object' && Object.prototype.hasOwnProperty.call(value, key);
 }
 
 const unsafeObjectProperties = new Set(['__proto__', 'prototype', 'constructor', 'getPrototypeOf']);

--- a/packages/workflow/test/utils.test.ts
+++ b/packages/workflow/test/utils.test.ts
@@ -343,19 +343,19 @@ describe('hasKey', () => {
 
 		expect(result).toEqual(false);
 	});
-	it('should return false if the input is an object without the key', () => {
-		const x = { a: 3 };
-		const result = hasKey(x, 'a');
+       it('should return false if the input is an object without the key', () => {
+               const x = { a: 3 };
+               const result = hasKey(x, 'b');
 
-		expect(result).toEqual(true);
-	});
+               expect(result).toEqual(false);
+       });
 
-	it('should return true if the input is an object with the key', () => {
-		const x = { a: 3 };
-		const result = hasKey(x, 'b');
+       it('should return true if the input is an object with the key', () => {
+               const x = { a: 3 };
+               const result = hasKey(x, 'a');
 
-		expect(result).toEqual(false);
-	});
+               expect(result).toEqual(true);
+       });
 
 	it('should provide a type guard', () => {
 		const x: unknown = { a: 3 };


### PR DESCRIPTION
## Summary
- fix `hasKey` utility to safely check for property existence
- correct object property tests to match expectations

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.11.1.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68407ccff9a8832b8dae5586644c491e